### PR TITLE
Change signature of environment

### DIFF
--- a/src/main/java/com/mattmalec/pterodactyl4j/application/entities/Container.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/application/entities/Container.java
@@ -7,6 +7,6 @@ public interface Container {
 	String getStartupCommand();
 	String getImage();
 	boolean isInstalled();
-	Map<String, String> getEnvironment();
+	Map<String, Object> getEnvironment();
 
 }

--- a/src/main/java/com/mattmalec/pterodactyl4j/application/entities/impl/ContainerImpl.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/application/entities/impl/ContainerImpl.java
@@ -31,10 +31,10 @@ public class ContainerImpl implements Container {
     }
 
     @Override
-    public Map<String, String> getEnvironment() {
+    public Map<String, Object> getEnvironment() {
         JSONObject environment = json.getJSONObject("environment");
-        HashMap<String, String> environmentMap = new HashMap<>();
-        environment.keys().forEachRemaining(s -> environmentMap.putIfAbsent(s, environment.getString(s)));
+        HashMap<String, Object> environmentMap = new HashMap<>();
+        environment.keys().forEachRemaining(s -> environmentMap.putIfAbsent(s, environment.get(s)));
         return Collections.unmodifiableMap(environmentMap);
     }
 }

--- a/src/main/java/com/mattmalec/pterodactyl4j/application/entities/impl/CreateServerImpl.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/application/entities/impl/CreateServerImpl.java
@@ -33,7 +33,7 @@ public class CreateServerImpl implements ServerAction {
 	private long databases = 0L;
 	private long allocations = 0L;
 	private long backups = 0L;
-	private Map<String, String> environment;
+	private Map<String, Object> environment;
 	private Set<Location> locations;
 	private Set<Integer> portRange;
 	private boolean useDedicatedIP;
@@ -158,7 +158,7 @@ public class CreateServerImpl implements ServerAction {
 	}
 
 	@Override
-	public ServerAction setEnvironment(Map<String, String> environment) {
+	public ServerAction setEnvironment(Map<String, Object> environment) {
 		this.environment = environment;
 		return this;
 	}

--- a/src/main/java/com/mattmalec/pterodactyl4j/application/managers/ServerAction.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/application/managers/ServerAction.java
@@ -23,7 +23,7 @@ public interface ServerAction {
 	ServerAction setDatabases(long amount);
 	ServerAction setAllocations(long amount);
 	ServerAction setBackups(long amount);
-	ServerAction setEnvironment(Map<String, String> environment);
+	ServerAction setEnvironment(Map<String, Object> environment);
 	ServerAction setLocations(Set<Location> locations);
 	default ServerAction setLocation(Location location) {
 		return setLocations(Collections.singleton(location));


### PR DESCRIPTION
Pterodactyl uses not only strings as values for their environment variables (can be seen in the official api documentation example: https://dashflo.net/docs/api/pterodactyl/v1/#req_190b1006d60748abbeda37c7d407345a). This also causes some json related exceptions when trying to get a property from the JSONObject as string which is not a string.

This pull request addresses this issue by changing the type of the map from Map<String, String> to Map<String, Object>