### PR TITLE
Add backup restore permission

### DIFF
--- a/src/main/java/com/mattmalec/pterodactyl4j/Permission.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/Permission.java
@@ -31,6 +31,7 @@ public enum Permission {
     BACKUP_UPDATE("backup.update", ""),
     BACKUP_DELETE("backup.delete", "Allows a user to remove backups from the system."),
     BACKUP_DOWNLOAD("backup.download", "Allows a user to download backups."),
+    BACKUP_RESTORE("backup.restore", "Allows a user to restore backups for the server."),
 
     ALLOCATION_READ("allocation.read", "Allows a user to view all allocations currently assigned to this server. Users with any level of access to this server can always view the primary allocation."),
     ALLOCATION_CREATE("allocation.create", "Allows a user to assign additional allocations to the server."),
@@ -62,7 +63,7 @@ public enum Permission {
     public static final Permission[] DATABASE_PERMISSIONS   = new Permission[] { DATABASE_READ, DATABASE_CREATE, DATABASE_UPDATE, DATABASE_DELETE, DATABASE_VIEW_PASSWORD };
     public static final Permission[] SCHEDULE_PERMISSIONS   = new Permission[] { SCHEDULE_READ, SCHEDULE_CREATE, SCHEDULE_UPDATE, SCHEDULE_DELETE };
     public static final Permission[] USER_PERMISSIONS       = new Permission[] { USER_READ, USER_CREATE, USER_UPDATE, USER_DELETE };
-    public static final Permission[] BACKUP_PERMISSIONS     = new Permission[] { BACKUP_READ, BACKUP_CREATE, BACKUP_UPDATE, BACKUP_DELETE, BACKUP_DOWNLOAD };
+    public static final Permission[] BACKUP_PERMISSIONS     = new Permission[] { BACKUP_READ, BACKUP_CREATE, BACKUP_UPDATE, BACKUP_DELETE, BACKUP_DOWNLOAD, BACKUP_RESTORE };
     public static final Permission[] ALLOCATION_PERMISSIONS = new Permission[] { ALLOCATION_READ, ALLOCATION_CREATE, ALLOCATION_UPDATE, ALLOCATION_DELETE };
     public static final Permission[] FILE_PERMISSIONS       = new Permission[] { FILE_READ, FILE_READ_CONTENT, FILE_CREATE, FILE_UPDATE, FILE_DELETE, FILE_ARCHIVE, FILE_SFTP };
     public static final Permission[] STARTUP_PERMISSIONS    = new Permission[] { STARTUP_READ, STARTUP_UPDATE };


### PR DESCRIPTION
Adds support for the undocumented Pterodactyl backup restore permission:
![image](https://user-images.githubusercontent.com/10583568/120661771-7869f500-c480-11eb-9ffc-31a4c5132b43.png)
