### PR TITLE
Added "month" and "only_when_online" to Schedule creation action

### DIFF
--- a/src/main/java/com/mattmalec/pterodactyl4j/client/entities/Cron.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/client/entities/Cron.java
@@ -20,6 +20,7 @@ public interface Cron {
 
 	String getDayOfWeek();
 	String getDayOfMonth();
+	String getMonth();
 	String getHour();
 	String getMinute();
 	String getExpression();

--- a/src/main/java/com/mattmalec/pterodactyl4j/client/entities/Schedule.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/client/entities/Schedule.java
@@ -30,6 +30,7 @@ public interface Schedule extends ISnowflake {
 	String getName();
 	Cron getCron();
 	boolean isActive();
+	boolean isOnlyWhenServerIsOnline();
 	boolean isProcessing();
 	Optional<OffsetDateTime> getLastRunDate();
 	OffsetDateTime getNextRunDate();

--- a/src/main/java/com/mattmalec/pterodactyl4j/client/entities/impl/CreateScheduleImpl.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/client/entities/impl/CreateScheduleImpl.java
@@ -17,6 +17,7 @@
 package com.mattmalec.pterodactyl4j.client.entities.impl;
 
 import com.mattmalec.pterodactyl4j.client.entities.ClientServer;
+import com.mattmalec.pterodactyl4j.client.managers.ScheduleAction;
 import com.mattmalec.pterodactyl4j.requests.Route;
 import com.mattmalec.pterodactyl4j.requests.action.AbstractScheduleAction;
 import com.mattmalec.pterodactyl4j.utils.Checks;
@@ -35,10 +36,13 @@ public class CreateScheduleImpl extends AbstractScheduleAction {
 		JSONObject json = new JSONObject()
 				.put("name", name)
 				.put("is_active", active)
+				.put("only_when_online", whenServerIsOnline == null || whenServerIsOnline)
 				.put("minute", minute == null ? cron.getMinute() : minute)
 				.put("hour", hour == null ? cron.getHour() : hour)
 				.put("day_of_week", dayOfWeek == null ? cron.getDayOfWeek() : dayOfWeek)
+				.put("month", month == null ? cron.getMonth() : month)
 				.put("day_of_month", dayOfMonth == null ? cron.getDayOfMonth() : dayOfMonth);
 		return getRequestBody(json);
 	}
+
 }

--- a/src/main/java/com/mattmalec/pterodactyl4j/client/entities/impl/CronImpl.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/client/entities/impl/CronImpl.java
@@ -38,6 +38,11 @@ public class CronImpl implements Cron {
 	}
 
 	@Override
+	public String getMonth() {
+		return json.getString("month");
+	}
+
+	@Override
 	public String getHour() {
 		return json.getString("hour");
 	}
@@ -54,12 +59,13 @@ public class CronImpl implements Cron {
 
 	public static Cron ofExpression(String expression) {
 		String[] exp = expression.split("\\s+");
-		if(exp.length != 4) throw new IllegalArgumentException("P4J Cron Expression must have 4 elements (minute, hour, day of month, day of week)");
+		if(exp.length != 5) throw new IllegalArgumentException("P4J Cron Expression must have 5 elements (minute, hour, day of month, month, day of week)");
 		JSONObject cron = new JSONObject();
 		cron.put("minute", exp[0])
 				.put("hour", exp[1])
 				.put("day_of_month", exp[2])
-				.put("day_of_week", exp[3]);
+				.put("month", exp[3])
+				.put("day_of_week", exp[4]);
 		return new CronImpl(new JSONObject().put("cron", cron));
 	}
 }

--- a/src/main/java/com/mattmalec/pterodactyl4j/client/entities/impl/CronImpl.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/client/entities/impl/CronImpl.java
@@ -54,7 +54,7 @@ public class CronImpl implements Cron {
 
 	@Override
 	public String getExpression() {
-		return String.format("%s %s %s %s", getMinute(), getHour(), getDayOfMonth(), getDayOfWeek());
+		return String.format("%s %s %s %s %s", getMinute(), getHour(), getDayOfMonth(), getMonth(), getDayOfWeek());
 	}
 
 	public static Cron ofExpression(String expression) {

--- a/src/main/java/com/mattmalec/pterodactyl4j/client/entities/impl/ScheduleImpl.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/client/entities/impl/ScheduleImpl.java
@@ -75,6 +75,11 @@ public class ScheduleImpl implements Schedule {
 	}
 
 	@Override
+	public boolean isOnlyWhenServerIsOnline() {
+		return json.getBoolean("only_when_online");
+	}
+
+	@Override
 	public boolean isProcessing() {
 		return json.getBoolean("is_processing");
 	}

--- a/src/main/java/com/mattmalec/pterodactyl4j/client/managers/ScheduleAction.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/client/managers/ScheduleAction.java
@@ -24,11 +24,13 @@ public interface ScheduleAction extends PteroAction<Schedule> {
 
 	ScheduleAction setName(String name);
 	ScheduleAction setActive(boolean active);
+	ScheduleAction setWhenServerIsOnline(boolean whenServerIsOnline);
 	ScheduleAction setCron(Cron cron);
 	ScheduleAction setCronExpression(String expression);
 	ScheduleAction setMinute(String minute);
 	ScheduleAction setHour(String hour);
 	ScheduleAction setDayOfWeek(String dayOfWeek);
+	ScheduleAction setMonth(String month);
 	ScheduleAction setDayOfMonth(String dayOfMonth);
 
 }

--- a/src/main/java/com/mattmalec/pterodactyl4j/requests/action/AbstractScheduleAction.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/requests/action/AbstractScheduleAction.java
@@ -30,10 +30,12 @@ public abstract class AbstractScheduleAction extends PteroActionImpl<Schedule> i
 
     protected String name;
     protected Boolean active;
+    protected Boolean whenServerIsOnline;
     protected Cron cron;
     protected String minute;
     protected String hour;
     protected String dayOfWeek;
+    protected String month;
     protected String dayOfMonth;
 
     public AbstractScheduleAction(PteroClientImpl impl, ClientServer server, Route.CompiledRoute route) {
@@ -49,6 +51,12 @@ public abstract class AbstractScheduleAction extends PteroActionImpl<Schedule> i
     @Override
     public ScheduleAction setActive(boolean active) {
         this.active = active;
+        return this;
+    }
+
+    @Override
+    public ScheduleAction setWhenServerIsOnline(boolean whenServerIsOnline) {
+        this.whenServerIsOnline = whenServerIsOnline;
         return this;
     }
 
@@ -79,6 +87,12 @@ public abstract class AbstractScheduleAction extends PteroActionImpl<Schedule> i
     @Override
     public ScheduleAction setDayOfWeek(String dayOfWeek) {
         this.dayOfWeek = dayOfWeek;
+        return this;
+    }
+
+    @Override
+    public ScheduleAction setMonth(String month) {
+        this.month = month;
         return this;
     }
 


### PR DESCRIPTION
The Pterodactyl Api docs are outdated. The endpoint /api/client/servers/xxxxxx/schedules (Create schedule) need this:

{
  "name": "Minute Hello",
  "minute": "*",
  "hour": "*",
  "day_of_month": "*",
  "day_of_week": "*",
  **"month":"*",**
  "is_active": true,
  **"only_when_online":true**
}