### PR TITLE
Added uptime to websocket statsupdate

### DIFF
--- a/src/main/java/com/mattmalec/pterodactyl4j/client/ws/events/StatsUpdateEvent.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/client/ws/events/StatsUpdateEvent.java
@@ -80,5 +80,14 @@ public class StatsUpdateEvent extends Event {
         return String.format("%.2f %s", getNetworkEgress() / (dataType.getMbValue() * Math.pow(2, 20)), dataType.name());
     }
 
+    public long getUptime() {
+        return stats.getLong("uptime");
+    }
 
+    public String getUptimeFormatted(){
+        long second = (stats.getLong("uptime") / 1000) % 60;
+        long minute = (stats.getLong("uptime") / (1000 * 60)) % 60;
+        long hour = (stats.getLong("uptime") / (1000 * 60 * 60)) % 24;
+        return String.format("%02d:%02d:%02d", hour, minute, second);
+    }
 }


### PR DESCRIPTION
Hey,

With the new Panel and Wings release (1.6.3 and 1.5.2) the "Uptime" feature has been added to the Websocket Statsupdate event.

As usual: If there are any problems please let me know and I'll try to fix them!

Greetings,
lokerhp