### PR TITLE
Fix NullPointerException in WebSocketClient

### DIFF
--- a/src/main/java/com/mattmalec/pterodactyl4j/client/ws/WebSocketClient.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/client/ws/WebSocketClient.java
@@ -134,10 +134,11 @@ public class WebSocketClient extends WebSocketListener implements Runnable {
 	}
 
 	private void handleEvent(String event, String args) {
-		ClientSocketHandler handler = getHandler(event);
-		if (handler == null) {
-			return; // Don't even bother trying to handle an event which we don't know
+		if (!handlers.containsKey(event)) {
+			WEBSOCKET_LOG.trace("Received an unknown websocket event {}", event);
+			return;
 		}
+		ClientSocketHandler handler = getHandler(event);
 
 		if (freshServer)
 			client.retrieveServerByIdentifier(server.getIdentifier())

--- a/src/main/java/com/mattmalec/pterodactyl4j/client/ws/WebSocketClient.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/client/ws/WebSocketClient.java
@@ -135,6 +135,9 @@ public class WebSocketClient extends WebSocketListener implements Runnable {
 
 	private void handleEvent(String event, String args) {
 		ClientSocketHandler handler = getHandler(event);
+		if (handler == null) {
+			return; // Don't even bother trying to handle an event which we don't know
+		}
 
 		if (freshServer)
 			client.retrieveServerByIdentifier(server.getIdentifier())

--- a/src/main/java/com/mattmalec/pterodactyl4j/client/ws/WebSocketClient.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/client/ws/WebSocketClient.java
@@ -135,7 +135,7 @@ public class WebSocketClient extends WebSocketListener implements Runnable {
 
 	private void handleEvent(String event, String args) {
 		if (!handlers.containsKey(event)) {
-			WEBSOCKET_LOG.trace("Received an unknown websocket event {}", event);
+			WEBSOCKET_LOG.trace("Received an unknown websocket event: {}", event);
 			return;
 		}
 		ClientSocketHandler handler = getHandler(event);


### PR DESCRIPTION
This fixes a NullPointerException in WebSocketClient when an unknown event via the WebSocket connection has been received. This ensures compatibility with 3rd party forks of Pterodactyl and future versions of it.