### PR TITLE
Fix #73 and #75: 401 code edge case and exceptions thrown recursively when url is invalid 

### DIFF
--- a/src/main/java/com/mattmalec/pterodactyl4j/requests/RateLimiter.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/requests/RateLimiter.java
@@ -1,5 +1,5 @@
 /*
- *    Copyright 2021-2022 Matt Malec, and the Pterodactyl4J contributors
+ *    Copyright 2021-2023 Matt Malec, and the Pterodactyl4J contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -156,6 +156,7 @@ public class RateLimiter implements Runnable {
 			} catch (Exception ex) {
 				RATELIMIT_LOG.error("Encountered exception trying to execute request");
 				ex.printStackTrace();
+				iterator.remove();
 				break;
 			}
 		}

--- a/src/main/java/com/mattmalec/pterodactyl4j/requests/Request.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/requests/Request.java
@@ -70,11 +70,12 @@ public class Request<T> {
 			onFailure(new RateLimitedException(route, response.getRetryAfter()));
 		} else
 			switch (response.getCode()) {
-				case 403:
-					onFailure(new LoginException(
+				case 401:
+                case 403:
+                    onFailure(new LoginException(
 							"The provided token is either incorrect or does not have access to process this request."));
 					break;
-				case 404:
+                case 404:
 					onFailure(new NotFoundException("The requested entity was not found."));
 					break;
 				case 422:


### PR DESCRIPTION
Hey, Here is the pull request to fix these two issue I found : #75 and #73.

Summary: 
- RateLimiter removes request element from it's iterator when it fails.
- Added a case check for response code 401 in the Request class