### PR TITLE
Add option to set target directory for archiving actions

### DIFF
--- a/src/main/java/com/mattmalec/pterodactyl4j/client/entities/Directory.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/client/entities/Directory.java
@@ -17,10 +17,8 @@
 package com.mattmalec.pterodactyl4j.client.entities;
 
 import com.mattmalec.pterodactyl4j.PteroAction;
-import com.mattmalec.pterodactyl4j.client.managers.CompressAction;
-import com.mattmalec.pterodactyl4j.client.managers.DeleteAction;
-import com.mattmalec.pterodactyl4j.client.managers.RenameAction;
-import com.mattmalec.pterodactyl4j.client.managers.UploadFileAction;
+import com.mattmalec.pterodactyl4j.client.managers.*;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -67,5 +65,5 @@ public interface Directory extends GenericFile {
 
 	CompressAction compress();
 
-	PteroAction<Void> decompress(File compressedFile);
+	DecompressAction decompress(File compressedFile);
 }

--- a/src/main/java/com/mattmalec/pterodactyl4j/client/entities/File.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/client/entities/File.java
@@ -17,6 +17,7 @@
 package com.mattmalec.pterodactyl4j.client.entities;
 
 import com.mattmalec.pterodactyl4j.PteroAction;
+import com.mattmalec.pterodactyl4j.client.managers.DecompressAction;
 
 public interface File extends GenericFile {
 
@@ -28,5 +29,5 @@ public interface File extends GenericFile {
 
 	PteroAction<Void> copy();
 
-	PteroAction<Void> decompress();
+	DecompressAction decompress();
 }

--- a/src/main/java/com/mattmalec/pterodactyl4j/client/entities/impl/CompressActionImpl.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/client/entities/impl/CompressActionImpl.java
@@ -17,6 +17,7 @@
 package com.mattmalec.pterodactyl4j.client.entities.impl;
 
 import com.mattmalec.pterodactyl4j.client.entities.ClientServer;
+import com.mattmalec.pterodactyl4j.client.entities.Directory;
 import com.mattmalec.pterodactyl4j.client.entities.File;
 import com.mattmalec.pterodactyl4j.client.entities.GenericFile;
 import com.mattmalec.pterodactyl4j.client.managers.CompressAction;
@@ -24,6 +25,7 @@ import com.mattmalec.pterodactyl4j.requests.PteroActionImpl;
 import com.mattmalec.pterodactyl4j.requests.Route;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 import okhttp3.RequestBody;
@@ -32,6 +34,7 @@ import org.json.JSONObject;
 public class CompressActionImpl extends PteroActionImpl<File> implements CompressAction {
 
 	private final List<GenericFile> files;
+    private Directory rootDirectory;
 
 	public CompressActionImpl(ClientServer server, PteroClientImpl impl) {
 		super(
@@ -39,6 +42,7 @@ public class CompressActionImpl extends PteroActionImpl<File> implements Compres
 				Route.Files.COMPRESS_FILES.compile(server.getIdentifier()),
 				(response, request) -> new FileImpl(response.getObject(), "/", server));
 		this.files = new ArrayList<>();
+        setHandler((response, request) -> new FileImpl(response.getObject(), (rootDirectory == null ? "/" : rootDirectory.getPath()), server));
 	}
 
 	@Override
@@ -55,6 +59,12 @@ public class CompressActionImpl extends PteroActionImpl<File> implements Compres
 
 		return this;
 	}
+
+    @Override
+    public CompressAction setRoot(Directory rootDirectory) {
+        this.rootDirectory = rootDirectory;
+        return this;
+    }
 
 	@Override
 	public CompressAction clearFiles() {

--- a/src/main/java/com/mattmalec/pterodactyl4j/client/entities/impl/CompressActionImpl.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/client/entities/impl/CompressActionImpl.java
@@ -51,6 +51,12 @@ public class CompressActionImpl extends PteroActionImpl<File> implements Compres
 		return this;
 	}
 
+    @Override
+    public CompressAction addFiles(Collection<GenericFile> files) {
+        this.files.addAll(files);
+        return this;
+    }
+
 	@Override
 	public CompressAction addFiles(GenericFile file, GenericFile... files) {
 		this.files.add(file);

--- a/src/main/java/com/mattmalec/pterodactyl4j/client/entities/impl/DecompressActionImpl.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/client/entities/impl/DecompressActionImpl.java
@@ -17,16 +17,21 @@
 package com.mattmalec.pterodactyl4j.client.entities.impl;
 
 import com.mattmalec.pterodactyl4j.client.entities.ClientServer;
+import com.mattmalec.pterodactyl4j.client.entities.Directory;
 import com.mattmalec.pterodactyl4j.client.entities.File;
+import com.mattmalec.pterodactyl4j.client.managers.DecompressAction;
+import com.mattmalec.pterodactyl4j.exceptions.IllegalActionException;
 import com.mattmalec.pterodactyl4j.requests.PteroActionImpl;
 import com.mattmalec.pterodactyl4j.requests.Route;
 import com.mattmalec.pterodactyl4j.utils.Checks;
 import okhttp3.RequestBody;
 import org.json.JSONObject;
 
-public class DecompressActionImpl extends PteroActionImpl<Void> {
+public class DecompressActionImpl extends PteroActionImpl<Void> implements DecompressAction {
 
 	private final File compressedFile;
+
+	private Directory rootDirectory;
 
 	public DecompressActionImpl(ClientServer server, File compressedFile, PteroClientImpl impl) {
 		super(impl.getP4J(), Route.Files.DECOMPRESS_FILE.compile(server.getIdentifier()));
@@ -34,10 +39,25 @@ public class DecompressActionImpl extends PteroActionImpl<Void> {
 	}
 
 	@Override
+	public DecompressAction setRoot(Directory rootDirectory) {
+		this.rootDirectory = rootDirectory;
+		return this;
+	}
+
+	@Override
 	protected RequestBody finalizeData() {
 		Checks.notNull(compressedFile, "Compressed File");
 
-		JSONObject json = new JSONObject().put("file", compressedFile.getPath()).put("root", "/");
+		if(rootDirectory == null) {
+			JSONObject json = new JSONObject().put("root", "/").put("file", compressedFile.getPath());
+			return getRequestBody(json);
+		}
+		String rootPath = rootDirectory.getPath() + "/";
+		String filePath = compressedFile.getPath();
+		if(!filePath.startsWith(rootPath)) {
+			throw new IllegalActionException("compressed file isn't within the given root directory");
+		}
+		JSONObject json = new JSONObject().put("root", rootDirectory.getPath()).put("file", filePath.substring(rootPath.length()));
 		return getRequestBody(json);
 	}
 }

--- a/src/main/java/com/mattmalec/pterodactyl4j/client/entities/impl/DecompressActionImpl.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/client/entities/impl/DecompressActionImpl.java
@@ -49,7 +49,24 @@ public class DecompressActionImpl extends PteroActionImpl<Void> implements Decom
 		Checks.notNull(compressedFile, "Compressed File");
 
 		if(rootDirectory == null) {
-			JSONObject json = new JSONObject().put("root", "/").put("file", compressedFile.getPath());
+			String filePath = compressedFile.getPath();
+
+			if(filePath.endsWith("/")) {
+				filePath = filePath.substring(0, filePath.length() - 1);
+			}
+
+			int lastSlashIndex = filePath.lastIndexOf('/');
+			String parentDir;
+
+			if(lastSlashIndex == -1) {
+				parentDir = "/";
+				filePath = compressedFile.getPath();
+			} else {
+				parentDir = filePath.substring(0, lastSlashIndex);
+				filePath = filePath.substring(lastSlashIndex + 1);
+			}
+
+			JSONObject json = new JSONObject().put("root", parentDir).put("file", filePath);
 			return getRequestBody(json);
 		}
 		String rootPath = rootDirectory.getPath() + "/";

--- a/src/main/java/com/mattmalec/pterodactyl4j/client/entities/impl/DirectoryImpl.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/client/entities/impl/DirectoryImpl.java
@@ -21,10 +21,8 @@ import com.mattmalec.pterodactyl4j.client.entities.ClientServer;
 import com.mattmalec.pterodactyl4j.client.entities.Directory;
 import com.mattmalec.pterodactyl4j.client.entities.File;
 import com.mattmalec.pterodactyl4j.client.entities.GenericFile;
-import com.mattmalec.pterodactyl4j.client.managers.CompressAction;
-import com.mattmalec.pterodactyl4j.client.managers.DeleteAction;
-import com.mattmalec.pterodactyl4j.client.managers.RenameAction;
-import com.mattmalec.pterodactyl4j.client.managers.UploadFileAction;
+import com.mattmalec.pterodactyl4j.client.managers.*;
+
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -78,7 +76,7 @@ public class DirectoryImpl implements Directory {
 	}
 
 	@Override
-	public PteroAction<Void> decompress(File compressedFile) {
+	public DecompressAction decompress(File compressedFile) {
 		return server.getFileManager().decompress(compressedFile);
 	}
 

--- a/src/main/java/com/mattmalec/pterodactyl4j/client/entities/impl/FileImpl.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/client/entities/impl/FileImpl.java
@@ -20,6 +20,7 @@ import com.mattmalec.pterodactyl4j.PteroAction;
 import com.mattmalec.pterodactyl4j.client.entities.ClientServer;
 import com.mattmalec.pterodactyl4j.client.entities.DownloadableFile;
 import com.mattmalec.pterodactyl4j.client.entities.File;
+import com.mattmalec.pterodactyl4j.client.managers.DecompressAction;
 import com.mattmalec.pterodactyl4j.client.managers.FileManager;
 import org.json.JSONObject;
 
@@ -53,7 +54,7 @@ public class FileImpl extends GenericFileImpl implements File {
 	}
 
 	@Override
-	public PteroAction<Void> decompress() {
+	public DecompressAction decompress() {
 		return fileManager.decompress(this);
 	}
 }

--- a/src/main/java/com/mattmalec/pterodactyl4j/client/entities/impl/FileManagerImpl.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/client/entities/impl/FileManagerImpl.java
@@ -64,7 +64,7 @@ public class FileManagerImpl implements FileManager {
 	}
 
 	@Override
-	public PteroAction<Void> decompress(File compressedFile) {
+	public DecompressAction decompress(File compressedFile) {
 		return new DecompressActionImpl(server, compressedFile, impl);
 	}
 

--- a/src/main/java/com/mattmalec/pterodactyl4j/client/managers/CompressAction.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/client/managers/CompressAction.java
@@ -17,14 +17,18 @@
 package com.mattmalec.pterodactyl4j.client.managers;
 
 import com.mattmalec.pterodactyl4j.PteroAction;
+import com.mattmalec.pterodactyl4j.client.entities.Directory;
 import com.mattmalec.pterodactyl4j.client.entities.File;
 import com.mattmalec.pterodactyl4j.client.entities.GenericFile;
 
+import java.util.Collection;
 public interface CompressAction extends PteroAction<File> {
 
 	CompressAction addFile(GenericFile file);
 
 	CompressAction addFiles(GenericFile file, GenericFile... files);
+
+	CompressAction setRoot(Directory rootDirectory);
 
 	CompressAction clearFiles();
 }

--- a/src/main/java/com/mattmalec/pterodactyl4j/client/managers/CompressAction.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/client/managers/CompressAction.java
@@ -26,6 +26,8 @@ public interface CompressAction extends PteroAction<File> {
 
 	CompressAction addFile(GenericFile file);
 
+	CompressAction addFiles(Collection<GenericFile> files);
+
 	CompressAction addFiles(GenericFile file, GenericFile... files);
 
 	CompressAction setRoot(Directory rootDirectory);

--- a/src/main/java/com/mattmalec/pterodactyl4j/client/managers/DecompressAction.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/client/managers/DecompressAction.java
@@ -1,0 +1,8 @@
+package com.mattmalec.pterodactyl4j.client.managers;
+
+import com.mattmalec.pterodactyl4j.PteroAction;
+import com.mattmalec.pterodactyl4j.client.entities.Directory;
+
+public interface DecompressAction extends PteroAction<Void> {
+    DecompressAction setRoot(Directory rootDirectory);
+}

--- a/src/main/java/com/mattmalec/pterodactyl4j/client/managers/FileManager.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/client/managers/FileManager.java
@@ -33,7 +33,7 @@ public interface FileManager {
 
 	CompressAction compress();
 
-	PteroAction<Void> decompress(File compressedFile);
+	DecompressAction decompress(File compressedFile);
 
 	DeleteAction delete();
 

--- a/src/main/java/com/mattmalec/pterodactyl4j/requests/PteroActionImpl.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/requests/PteroActionImpl.java
@@ -37,7 +37,7 @@ public class PteroActionImpl<T> implements PteroAction<T> {
 	private final Route.CompiledRoute route;
 	private final RequestBody data;
 	private long deadline = 0;
-	private final BiFunction<Response, Request<T>, T> handler;
+	private BiFunction<Response, Request<T>, T> handler;
 
 	public static <T> DeferredPteroAction<T> onExecute(P4J api, Supplier<? extends T> supplier) {
 		return new DeferredPteroAction<>(api, supplier);
@@ -134,6 +134,10 @@ public class PteroActionImpl<T> implements PteroAction<T> {
 	public void handleResponse(Response response, Request<T> request) {
 		if (response.isOk()) handleSuccess(response, request);
 		else request.setOnFailure(response);
+	}
+
+	public void setHandler(BiFunction<Response, Request<T>, T> handler) {
+		this.handler = handler;
 	}
 
 	public void handleSuccess(Response response, Request<T> request) {


### PR DESCRIPTION
Adds the option to set a root directory in both the CompressionAction and DecomressionAction.
This directory determines where the compressed archive will be put or where the archive to be decompressed is located, respectively.