### PR TITLE
Add method to retrieve accurate backup count

### DIFF
--- a/src/main/java/com/mattmalec/pterodactyl4j/client/entities/ClientServer.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/client/entities/ClientServer.java
@@ -88,6 +88,8 @@ public interface ClientServer extends Server {
 
 	SubuserManager getSubuserManager();
 
+	PteroAction<Integer> retrieveBackupCount();
+
 	PaginationAction<Backup> retrieveBackups();
 
 	PteroAction<Backup> retrieveBackup(UUID uuid);

--- a/src/main/java/com/mattmalec/pterodactyl4j/client/entities/impl/ClientServerImpl.java
+++ b/src/main/java/com/mattmalec/pterodactyl4j/client/entities/impl/ClientServerImpl.java
@@ -172,6 +172,19 @@ public class ClientServerImpl implements ClientServer {
 	}
 
 	@Override
+	public PteroAction<Integer> retrieveBackupCount() {
+		return PteroActionImpl.onRequestExecute(
+				impl.getP4J(),
+				Route.Backups.LIST_BACKUPS.compile(getIdentifier()),
+				(response, request) -> {
+					JSONObject object = response.getObject();
+					if (object.has("meta"))
+						return object.getJSONObject("meta").getInt("backup_count");
+					return -1;
+				});
+	}
+
+	@Override
 	public PaginationAction<Backup> retrieveBackups() {
 		return PaginationResponseImpl.onPagination(
 				impl.getP4J(),


### PR DESCRIPTION
Add a way to retrieve the backup count accurately, as counting backups can be unreliable due to truncation when there are too many.